### PR TITLE
TokenTools admin page displays an error when token Pattern is empty. …

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,8 @@
 
 * Fix: missing icon on View Token ribbon button.
 * All token libraries created under the CATS module root item will be availablle to content authors.
+* Tokens without a correct pattern will display an error message in the TokenTools.aspx admin page.
+* Tokens without correct pattern or output configuration will not be cached.
 
 ## 1.0.0
 

--- a/SitecoreSpark.SimpleTokens/Caching/CATSTokenCacheManager.cs
+++ b/SitecoreSpark.SimpleTokens/Caching/CATSTokenCacheManager.cs
@@ -121,6 +121,18 @@ namespace SitecoreSpark.CATS.Caching
                 if (_tokenCache.GetString(token.Pattern) != null)
                     Logger.Warn($"Duplicate token found! Token pattern: {token.Pattern}", typeof(CATSTokenCacheManager));
 
+                if (String.IsNullOrEmpty(token.Pattern))
+                {
+                    Logger.Warn($"Missing Pattern for token item ID {token.ItemID}; will not be cached.", typeof(TokenService));
+                    continue;
+                }
+
+                if (String.IsNullOrEmpty(token.Output))
+                {
+                    Logger.Warn($"Missing Output for token item ID {token.ItemID}; will not be cached.", typeof(TokenService));
+                    continue;
+                }
+
                 _tokenCache.SetString(token.Pattern, token.Output);
 
                 if (_tokenCache.InnerCache.Size >= _cacheMaxSize)

--- a/SitecoreSpark.SimpleTokens/sitecore/admin/TokenTools.aspx.cs
+++ b/SitecoreSpark.SimpleTokens/sitecore/admin/TokenTools.aspx.cs
@@ -31,9 +31,13 @@ namespace SitecoreSpark.CATS.sitecore.admin
 
             sb.Clear();
             sb.Append($"Token Count: {dbTokens.Count()}\n\n");
+
             foreach (var token in dbTokens)
             {
-                sb.Append($"{token.Pattern}\n");
+                if (String.IsNullOrEmpty(token.Pattern))
+                    sb.Append($"[No Pattern Defined] {{{token.ItemID}}}\n");
+                else
+                    sb.Append($"{token.Pattern}\n");
             }
 
             txtDatabaseTokens.Text = sb.ToString();


### PR DESCRIPTION
…Tokens without patterrn or output will not be cached.